### PR TITLE
feat: Add Linux auto-launch implementation

### DIFF
--- a/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/AutoLaunch.kt
+++ b/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/AutoLaunch.kt
@@ -28,6 +28,24 @@ class AutoLaunch(
      */
     suspend fun disable() = platformAutoLaunch.disable()
 
+
+    /**
+     * Checks if the application was started with the '--autostart=true' argument.
+     *
+     * This method inspects the JVM input arguments to determine if the application
+     * was launched through the autostart mechanism, by verifying if the specific
+     * argument is present.
+     *
+     * @return true if the application was started with the '--autostart=true' argument, false otherwise.
+     */
+    fun isStartedViaAutostart(): Boolean {
+        val inputArguments = System.getProperty("sun.java.command")?.split(" ") ?: emptyList()
+        println("Arguments fournis: $inputArguments")
+        return inputArguments.contains("--autostart=true")
+    }
+
+
+
     companion object {
         /**
          * Get the app resolved executable path

--- a/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/AutoLaunch.kt
+++ b/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/AutoLaunch.kt
@@ -43,7 +43,7 @@ class AutoLaunch(
     }
 
     private val config = AutoLaunchConfig(
-        appName = appPackageName,
+        appPackageName = appPackageName,
         appPath = appPath
     )
 

--- a/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunch.kt
+++ b/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunch.kt
@@ -7,6 +7,6 @@ internal interface PlatformAutoLaunch {
 }
 
 internal data class AutoLaunchConfig(
-    val appName: String,
+    val appPackageName: String,
     val appPath: String,
 )

--- a/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunchLinux.kt
+++ b/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunchLinux.kt
@@ -31,6 +31,7 @@ internal class PlatformAutoLaunchLinux(private val config: AutoLaunchConfig) : P
     // Modifies the content of the .desktop file to add necessary entries for autostart
     private fun modifyDesktopFileContent(content: String): String {
         val updatedContent = content.lines().toMutableList()
+
         // Ensure the file contains the necessary entries for autostart
         val entries = listOf(
             "X-GNOME-Autostart-enabled=true",
@@ -52,8 +53,23 @@ internal class PlatformAutoLaunchLinux(private val config: AutoLaunchConfig) : P
             }
         }
 
+        // Add --autostart=true to the Exec line
+        val execIndex = updatedContent.indexOfFirst { it.startsWith("Exec=") }
+        if (execIndex != -1) {
+            val execLine = updatedContent[execIndex]
+            if (!execLine.contains("--autostart=true")) {
+                println("Adding --autostart=true to the Exec line")
+                updatedContent[execIndex] = "$execLine --autostart=true"
+            }
+        } else {
+            // If Exec line does not exist, create a new one
+            println("Adding new Exec line with --autostart=true")
+            updatedContent.add("Exec=${config.appPath} --autostart=true")
+        }
+
         return updatedContent.joinToString("\n")
     }
+
 
     // Writes the modified .desktop file to the ~/.config/autostart directory
     private fun writeAutostartDesktopFile(content: String) {
@@ -102,6 +118,7 @@ internal class PlatformAutoLaunchLinux(private val config: AutoLaunchConfig) : P
             println("Autostart desktop file not found at: ${autostartFile.path}")
         }
     }
+
 }
 
 /*

--- a/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunchLinux.kt
+++ b/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunchLinux.kt
@@ -1,15 +1,111 @@
 package io.github.vinceglb.autolaunch
 
+import java.io.File
+
 internal class PlatformAutoLaunchLinux(private val config: AutoLaunchConfig) : PlatformAutoLaunch {
+
+    // Checks if the application is installed by looking for a corresponding .desktop file in /usr/share/applications
+    private fun isInstalled(): Boolean {
+        val appPackageName = config.appPackageName
+        val applicationsDirectory = File("/usr/share/applications")
+        val desktopFile = applicationsDirectory.listFiles()?.find { it.name.contains(appPackageName) && it.name.endsWith(".desktop") }
+        val isInstalled = desktopFile != null
+        println("Checking if app is installed: $isInstalled (package: $appPackageName)")
+        return isInstalled
+    }
+
+    // Retrieves the content of the application's .desktop file from /usr/share/applications
+    private fun getDesktopFileContent(): String? {
+        val appPackageName = config.appPackageName
+        val applicationsDirectory = File("/usr/share/applications")
+        val desktopFile = applicationsDirectory.listFiles()?.find { it.name.contains(appPackageName) && it.name.endsWith(".desktop") }
+        return if (desktopFile != null && desktopFile.exists()) {
+            println("Reading desktop file content from: ${desktopFile.path}")
+            desktopFile.readText()
+        } else {
+            println("Desktop file not found for package: $appPackageName")
+            null
+        }
+    }
+
+    // Modifies the content of the .desktop file to add necessary entries for autostart
+    private fun modifyDesktopFileContent(content: String): String {
+        val updatedContent = content.lines().toMutableList()
+        // Ensure the file contains the necessary entries for autostart
+        val entries = listOf(
+            "X-GNOME-Autostart-enabled=true",
+            "StartupNotify=false",
+            "X-GNOME-Autostart-Delay=10",
+            "X-MATE-Autostart-Delay=10",
+            "X-KDE-autostart-after=panel"
+        )
+
+        entries.forEach { entry ->
+            val key = entry.substringBefore("=")
+            val existingIndex = updatedContent.indexOfFirst { it.startsWith(key) }
+            if (existingIndex != -1) {
+                println("Updating existing entry: $key")
+                updatedContent[existingIndex] = entry
+            } else {
+                println("Adding new entry: $entry")
+                updatedContent.add(entry)
+            }
+        }
+
+        return updatedContent.joinToString("\n")
+    }
+
+    // Writes the modified .desktop file to the ~/.config/autostart directory
+    private fun writeAutostartDesktopFile(content: String) {
+        val autostartDirectory = File(System.getProperty("user.home"), ".config/autostart")
+        if (!autostartDirectory.exists()) {
+            println("Creating autostart directory at: ${autostartDirectory.path}")
+            autostartDirectory.mkdirs()
+        }
+        val autostartFile = File(autostartDirectory, "${config.appPackageName}.desktop")
+        println("Writing autostart desktop file to: ${autostartFile.path}")
+        autostartFile.writeText(content)
+    }
+
+    // Checks if autostart is enabled by looking for the .desktop file in ~/.config/autostart
     override suspend fun isEnabled(): Boolean {
-        TODO("Not yet implemented")
+        val autostartFile = File(System.getProperty("user.home"), ".config/autostart/${config.appPackageName}.desktop")
+        val isEnabled = autostartFile.exists()
+        println("Checking if autostart is enabled: $isEnabled (path: ${autostartFile.path})")
+        return isEnabled
     }
 
+    // Enables autostart by copying and modifying the application's .desktop file
     override suspend fun enable() {
-        TODO("Not yet implemented")
+        println("Enabling autostart for app: ${config.appPackageName}")
+        if (isInstalled()) {
+            val desktopFileContent = getDesktopFileContent()
+            if (desktopFileContent != null) {
+                val modifiedContent = modifyDesktopFileContent(desktopFileContent)
+                writeAutostartDesktopFile(modifiedContent)
+            } else {
+                println("Failed to enable autostart: desktop file content is null")
+            }
+        } else {
+            println("Failed to enable autostart: app is not installed")
+        }
     }
 
+    // Disables autostart by deleting the .desktop file in ~/.config/autostart
     override suspend fun disable() {
-        TODO("Not yet implemented")
+        println("Disabling autostart for app: ${config.appPackageName}")
+        val autostartFile = File(System.getProperty("user.home"), ".config/autostart/${config.appPackageName}.desktop")
+        if (autostartFile.exists()) {
+            println("Deleting autostart desktop file at: ${autostartFile.path}")
+            autostartFile.delete()
+        } else {
+            println("Autostart desktop file not found at: ${autostartFile.path}")
+        }
     }
 }
+
+/*
+To test this functionality, it is necessary to create a .deb package and install it on the system.
+Without installation via a .deb, no .desktop file will be automatically created in /usr/share/applications,
+which makes it impossible to verify the presence of the application and enable autostart.
+*/

--- a/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunchMacOS.kt
+++ b/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunchMacOS.kt
@@ -24,6 +24,7 @@ internal class PlatformAutoLaunchMacOS(private val config: AutoLaunchConfig) : P
             |    <key>ProgramArguments</key>
             |    <array>
             |        <string>${config.appPath}</string>
+            |        <string>--autostart=true</string>
             |    </array>
             |    <key>RunAtLoad</key>
             |    <true/>
@@ -36,4 +37,5 @@ internal class PlatformAutoLaunchMacOS(private val config: AutoLaunchConfig) : P
     override suspend fun disable(): Unit = withContext(Dispatchers.IO) {
         file.delete()
     }
+
 }

--- a/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunchMacOS.kt
+++ b/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunchMacOS.kt
@@ -6,7 +6,7 @@ import java.io.File
 
 internal class PlatformAutoLaunchMacOS(private val config: AutoLaunchConfig) : PlatformAutoLaunch {
     private val file =
-        File("${System.getProperty("user.home")}/Library/LaunchAgents/${config.appName}.plist")
+        File("${System.getProperty("user.home")}/Library/LaunchAgents/${config.appPackageName}.plist")
 
     override suspend fun isEnabled(): Boolean = withContext(Dispatchers.IO) {
         file.exists()
@@ -20,7 +20,7 @@ internal class PlatformAutoLaunchMacOS(private val config: AutoLaunchConfig) : P
             |<plist version="1.0">
             |<dict>
             |    <key>Label</key>
-            |    <string>${config.appName}</string>
+            |    <string>${config.appPackageName}</string>
             |    <key>ProgramArguments</key>
             |    <array>
             |        <string>${config.appPath}</string>

--- a/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunchWindows.kt
+++ b/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunchWindows.kt
@@ -20,7 +20,7 @@ internal class PlatformAutoLaunchWindows(
             )
             value == "${config.appPath} --autostart=true"
         } catch (e: Win32Exception) {
-            if (e.message?.contains("Le fichier spécifié est introuvable") == true) {
+            if (e.errorCode == 2) { // ERROR_FILE_NOT_FOUND
                 false
             } else {
                 throw e
@@ -32,7 +32,7 @@ internal class PlatformAutoLaunchWindows(
         // Check if the application path exists
         val appPath = File(config.appPath)
         if (!appPath.exists()) {
-            throw FileNotFoundException("Le fichier spécifié est introuvable: ${config.appPath}")
+            throw FileNotFoundException("File not found: ${config.appPath}")
         }
 
         // Create the registry key if it doesn't exist

--- a/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunchWindows.kt
+++ b/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunchWindows.kt
@@ -12,7 +12,7 @@ internal class PlatformAutoLaunchWindows(
         val value: String? = Advapi32Util.registryGetStringValue(
             WinReg.HKEY_CURRENT_USER,
             REGISTRY_KEY,
-            config.appName
+            config.appPackageName
         )
         value == config.appPath
     }
@@ -27,7 +27,7 @@ internal class PlatformAutoLaunchWindows(
         Advapi32Util.registrySetStringValue(
             WinReg.HKEY_CURRENT_USER,
             REGISTRY_KEY,
-            config.appName,
+            config.appPackageName,
             config.appPath
         )
     }
@@ -37,7 +37,7 @@ internal class PlatformAutoLaunchWindows(
             Advapi32Util.registryDeleteValue(
                 WinReg.HKEY_CURRENT_USER,
                 REGISTRY_KEY,
-                config.appName
+                config.appPackageName
             )
         }
     }

--- a/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunchWindows.kt
+++ b/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunchWindows.kt
@@ -14,7 +14,7 @@ internal class PlatformAutoLaunchWindows(
             REGISTRY_KEY,
             config.appPackageName
         )
-        value == config.appPath
+        value == "${config.appPath} --autostart=true"
     }
 
     override suspend fun enable(): Unit = withContext(Dispatchers.IO) {
@@ -23,12 +23,12 @@ internal class PlatformAutoLaunchWindows(
             Advapi32Util.registryCreateKey(WinReg.HKEY_CURRENT_USER, REGISTRY_KEY)
         }
 
-        // Set the value
+        // Set the value with the autostart argument
         Advapi32Util.registrySetStringValue(
             WinReg.HKEY_CURRENT_USER,
             REGISTRY_KEY,
             config.appPackageName,
-            config.appPath
+            "${config.appPath} --autostart=true"
         )
     }
 

--- a/sample/src/desktopMain/kotlin/Main.kt
+++ b/sample/src/desktopMain/kotlin/Main.kt
@@ -35,6 +35,8 @@ fun App() {
     val scope = rememberCoroutineScope()
     val autoLaunch = remember { AutoLaunch(appPackageName = "com.autolaunch.sample") }
     var isEnabled by remember { mutableStateOf(false) }
+    val isStartedViaAutostart = autoLaunch.isStartedViaAutostart()
+
 
     LaunchedEffect(Unit) {
         isEnabled = autoLaunch.isEnabled()
@@ -55,6 +57,15 @@ fun App() {
                 style = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
+
+
+            Text(
+                text = "The application was ${if (!isStartedViaAutostart) "not" else ""} started via autostart.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
 
             if (!AutoLaunch.isRunningFromDistributable) {
                 Text(


### PR DESCRIPTION
Implemented auto-launch functionality for Linux and fixed Windows implementation

1. Linux:
- Added methods to check if the application is installed by looking for the .desktop file in `/usr/share/applications`.
- Added functionality to modify the .desktop file to include auto-start settings.
- Enabled writing of the modified .desktop file to `~/.config/autostart` to activate auto-launch.
- Provided enable and disable methods for managing auto-start.
- Included comprehensive logging for each step to facilitate debugging.

2. Windows:
- Fixed the Windows registry handling to avoid "file not found" errors.
- The `isStartedViaAutostart()` method was corrected for Windows to ensure proper functionality.

3. New method to detect if the application has been launched via autostart:
- The implementation has been tested on Linux and Windows. macOS tests are still pending.
- Usage example:

  `val isStartedViaAutostart = autoLaunch.isStartedViaAutostart()`
