### PR TITLE
Don't keep cmd window open on windows

### DIFF
--- a/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunchWindows.kt
+++ b/auto-launch/src/commonMain/kotlin/io/github/vinceglb/autolaunch/PlatformAutoLaunchWindows.kt
@@ -14,7 +14,7 @@ internal class PlatformAutoLaunchWindows(
                 /* key = */ REGISTRY_KEY,
                 /* value = */ config.appPackageName
             )
-            value == "cmd /c cd /d \"${Path(config.appPath).parent}\" && \"${config.appPath}\" --autostart=true"
+            value == "cmd /c start \"${config.appPackageName}\" /D \"${Path(config.appPath).parent}\" \"${config.appPath}\" --autostart=true"
         } catch (e: Win32Exception) {
             if (e.errorCode == 2) { // ERROR_FILE_NOT_FOUND
                 false
@@ -44,7 +44,7 @@ internal class PlatformAutoLaunchWindows(
             /* root = */ WinReg.HKEY_CURRENT_USER,
             /* keyPath = */ REGISTRY_KEY,
             /* name = */ config.appPackageName,
-            /* value = */ "cmd /c cd /d \"${Path(config.appPath).parent}\" && \"${config.appPath}\" --autostart=true"
+            /* value = */ "cmd /c start \"${config.appPackageName}\" /D \"${Path(config.appPath).parent}\" \"${config.appPath}\" --autostart=true"
         )
     }
 


### PR DESCRIPTION
On Windows, launching the application via AutoLaunch currently spawns a persistent cmd window that remains open until either the window or the application is closed. This change ensures the cmd window appears only momentarily during startup and then closes automatically, while the main application continues running as before.